### PR TITLE
fix: correct 'Sucesfully Connected' to 'Successfully Connected' in socket.ts

### DIFF
--- a/src/renderer/src/utils/socket.ts
+++ b/src/renderer/src/utils/socket.ts
@@ -49,7 +49,7 @@ export function createRoom(name: string) {
     socket.emit("join-room", name, (resp) => {
         if (!resp.success) return toast(`Failed Connect to Room ${name}`)
         else {
-            toast(`Sucesfully Connected to ${name}`)
+            toast(`Successfully Connected to ${name}`)
             setSocketRoom(name)
         }
     });


### PR DESCRIPTION
## Summary
Fix user-facing typo in socket connection toast notification (socket.ts line 52):

- **Before**: `Sucesfully Connected to ${name}`
- **After**: `Successfully Connected to ${name}`

Simple 1-line surgical fix.

---
*Submitted via automated PR攻关 agent*